### PR TITLE
Fix method call for first time use

### DIFF
--- a/Assets/Demos/AssetBundle/AssetBundleDemo.cs
+++ b/Assets/Demos/AssetBundle/AssetBundleDemo.cs
@@ -67,7 +67,7 @@ public class AssetBundleDemo : MonoBehaviour
 	{
 		UnloadAssetBundle ();
 		string filename = assetBundleName + "-" + GetAssetBundlePlatformName () + ".unity3d";
-		string url = Path.Combine (client.SecondaryEndpoint () + container, filename);
+		string url = Path.Combine (client.PrimaryEndpoint () + container, filename);
 		Log.Text (label, "Load asset bundle: " + url, "Load asset bundle: " + url);
 		StartCoroutine (LoadAssetBundleURL (url));
 	}

--- a/Assets/StorageServices/blob/BlobService.cs
+++ b/Assets/StorageServices/blob/BlobService.cs
@@ -46,7 +46,7 @@ namespace Unity3dAzure.StorageServices
 		public IEnumerator GetTextBlob (Action<RestResponse> callback, string resourcePath = "")
 		{
 			// public request
-			string url = UrlHelper.BuildQuery (client.SecondaryEndpoint (), "", resourcePath);
+			string url = UrlHelper.BuildQuery (client.PrimaryEndpoint (), "", resourcePath);
 			StorageRequest request = new StorageRequest (url, Method.GET);
 			yield return request.request.Send ();
 			request.Result (callback);


### PR DESCRIPTION
Currently, the file path points to `SecondaryEndpoint`, which appends "-secondary" to the storage account name.

This pull request changes the `client.SecondaryEndpoint()` call to `client.PrimaryEndpoint()` where applicable to prevent throwing the following error when running the project for the first time. 

![image](https://user-images.githubusercontent.com/21690533/31956884-1881f222-b8aa-11e7-8005-93b68b67c2d3.png)
